### PR TITLE
Strip ticket parameter from URLs

### DIFF
--- a/Security/CasAuthenticator.php
+++ b/Security/CasAuthenticator.php
@@ -76,7 +76,13 @@ class CasAuthenticator extends AbstractGuardAuthenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
     {
-        return null;
+        // If authentication was successful, redirect to the current URI with
+        // the ticket parameter removed so that it is hidden from end-users.
+        if ($request->query->has($this->query_ticket_parameter)) {
+            return new RedirectResponse($this->removeCasTicket($request->getUri()));
+        } else {
+            return null;
+        }
     }
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
@@ -99,5 +105,41 @@ class CasAuthenticator extends AbstractGuardAuthenticator
     public function supportsRememberMe()
     {
         return false;
+    }
+
+    /**
+     * Strip the CAS 'ticket' parameter from a uri.
+     */
+    protected function removeCasTicket($uri) {
+      $parsed_url = parse_url($uri);
+      // If there are no query parameters, then there is nothing to do.
+      if (empty($parsed_url['query'])) {
+          return $uri;
+      }
+      parse_str($parsed_url['query'], $query_params);
+      // If there is no 'ticket' parameter, there is nothing to do.
+      if (!isset($query_params[$this->query_ticket_parameter])) {
+          return $uri;
+      }
+      // Remove the ticket parameter and rebuild the query string.
+      unset($query_params[$this->query_ticket_parameter]);
+      if (empty($query_params)) {
+          unset($parsed_url['query']);
+      } else {
+          $parsed_url['query'] = http_build_query($query_params);
+      }
+
+      // Rebuild the URI from the parsed components.
+      // Source: https://secure.php.net/manual/en/function.parse-url.php#106731
+      $scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+      $host     = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+      $port     = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
+      $user     = isset($parsed_url['user']) ? $parsed_url['user'] : '';
+      $pass     = isset($parsed_url['pass']) ? ':' . $parsed_url['pass']  : '';
+      $pass     = ($user || $pass) ? "$pass@" : '';
+      $path     = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+      $query    = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+      $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+      return "$scheme$user$pass$host$port$path$query$fragment";
     }
 }

--- a/Security/CasAuthenticator.php
+++ b/Security/CasAuthenticator.php
@@ -43,7 +43,7 @@ class CasAuthenticator extends AbstractGuardAuthenticator
             // Validate ticket
             $url = $this->server_validation_url.'?'.$this->query_ticket_parameter.'='.
                 $request->get($this->query_ticket_parameter).'&'.
-                $this->query_service_parameter.'='.$this->removeCasTicket($request->getUri());
+                $this->query_service_parameter.'='.urlencode($this->removeCasTicket($request->getUri()));
 
             $client = new Client();
             $response = $client->request('GET', $url, $this->options);
@@ -99,7 +99,7 @@ class CasAuthenticator extends AbstractGuardAuthenticator
      */
     public function start(Request $request, AuthenticationException $authException = null)
     {
-        return new RedirectResponse($this->server_login_url.'?'.$this->query_service_parameter.'='.$request->getUri());
+        return new RedirectResponse($this->server_login_url.'?'.$this->query_service_parameter.'='.urlencode($request->getUri()));
     }
 
     public function supportsRememberMe()

--- a/Security/CasAuthenticator.php
+++ b/Security/CasAuthenticator.php
@@ -43,7 +43,7 @@ class CasAuthenticator extends AbstractGuardAuthenticator
             // Validate ticket
             $url = $this->server_validation_url.'?'.$this->query_ticket_parameter.'='.
                 $request->get($this->query_ticket_parameter).'&'.
-                $this->query_service_parameter.'='.$request->getUri();
+                $this->query_service_parameter.'='.$this->removeCasTicket($request->getUri());
 
             $client = new Client();
             $response = $client->request('GET', $url, $this->options);


### PR DESCRIPTION
Hi @PRayno, thanks for publishing this bundle! This PR addresses three issues I found in testing:
1. The CAS ticket was left in the URL after authentication success, exposing it to the user such that they might bookmark a URL containing an old single-use ticket.
2. The user was redirected twice to the CAS server to log in due to a mis-matched service-url in the `serviceValidate` check.
3. The `service` parameter sent to the CAS server wasn't url-encoded, potentially causing problems if the application URL actually does have its own query parameters.

_An implementation note:_ To reduce dependencies and keep the configuration from needing to change, the `removeCasTicket($uri)` method uses built-in PHP functions on the raw URL string. An alternative implementation would require the Symfony router to be injected so that it could be used to generate URLs without the ticket parameter as described in [this Q&A](https://stackoverflow.com/questions/15477147/better-way-to-code-this-symfony2-url-redirect). Let me know if you'd prefer to inject the router (and add this to the configuration steps) and I can rework this PR.

Best,
Adam
