### PR TITLE
Populate attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ p_rayno_cas_auth:
 ```
 Note : the xml_namespace and options parameters are optionals
 
+If you want any to access user attributes from the CAS response, inject the session into the user-provider in services.yml :
+```yaml
+services:
+    prayno.cas_user_provider:
+        class: PRayno\CasAuthBundle\Security\User\CasUserProvider
+        arguments: ['@session']
+```
+
 Modify your security.xml with the following values (the provider in the following settings should not be used as it's just a very basic example) :
 ```yaml
 security:

--- a/Security/CasAuthenticator.php
+++ b/Security/CasAuthenticator.php
@@ -11,6 +11,7 @@ use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use PRayno\CasAuthBundle\Security\User\CasUserCredentialStoreInterface;
 
 class CasAuthenticator extends AbstractGuardAuthenticator
 {
@@ -79,6 +80,9 @@ class CasAuthenticator extends AbstractGuardAuthenticator
     public function getUser($credentials, UserProviderInterface $userProvider)
     {
         if (isset($credentials[$this->username_attribute])) {
+            if ($userProvider instanceof CasUserCredentialStoreInterface) {
+                $userProvider->storeUserCredentials($credentials);
+            }
             return $userProvider->loadUserByUsername($credentials[$this->username_attribute]);
         } else {
             return null;

--- a/Security/CasAuthenticator.php
+++ b/Security/CasAuthenticator.php
@@ -21,12 +21,14 @@ class CasAuthenticator extends AbstractGuardAuthenticator
     protected $query_ticket_parameter;
     protected $query_service_parameter;
     protected $options;
+    protected $client;
 
     /**
      * Process configuration
      * @param array $config
+     * @param optional Client $client
      */
-    public function __construct($config)
+    public function __construct($config, Client $client = null)
     {
         $this->server_login_url = $config['server_login_url'];
         $this->server_validation_url = $config['server_validation_url'];
@@ -35,6 +37,11 @@ class CasAuthenticator extends AbstractGuardAuthenticator
         $this->query_service_parameter = $config['query_service_parameter'];
         $this->query_ticket_parameter = $config['query_ticket_parameter'];
         $this->options = $config['options'];
+        if (is_null($client)) {
+            $this->client = new Client();
+        } else {
+            $this->client = $client;
+        }
     }
 
     /**
@@ -49,8 +56,7 @@ class CasAuthenticator extends AbstractGuardAuthenticator
                 $request->get($this->query_ticket_parameter).'&'.
                 $this->query_service_parameter.'='.urlencode($this->removeCasTicket($request->getUri()));
 
-            $client = new Client();
-            $response = $client->request('GET', $url, $this->options);
+            $response = $this->client->request('GET', $url, $this->options);
 
             $string = $response->getBody()->getContents();
 

--- a/Security/User/CasUser.php
+++ b/Security/User/CasUser.php
@@ -4,13 +4,15 @@
 namespace PRayno\CasAuthBundle\Security\User;
 
 use Symfony\Component\Security\Core\User\UserInterface;
+use PRayno\CasAuthBundle\Security\User\CasUserAttributesInterface;
 
-class CasUser implements UserInterface
+class CasUser implements UserInterface, CasUserAttributesInterface
 {
     private $username;
     private $password;
     private $salt;
     private $roles;
+    private $attributes;
 
     /**
      * @param $username
@@ -18,12 +20,13 @@ class CasUser implements UserInterface
      * @param $salt
      * @param array $roles
      */
-    public function __construct($username, $password, $salt, array $roles)
+    public function __construct($username, $password, $salt, array $roles, array $attributes = array())
     {
         $this->username = $username;
         $this->password = $password;
         $this->salt = $salt;
         $this->roles = $roles;
+        $this->attributes = $attributes;
     }
 
     /**
@@ -63,6 +66,27 @@ class CasUser implements UserInterface
      */
     public function eraseCredentials()
     {
+
+    }
+
+    /**
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @return mixed string, array, or null if not found.
+     */
+    public function getAttribute($name)
+    {
+        if (isset($this->attributes[$name])) {
+            return $this->attributes[$name];
+        } else {
+            return null;
+        }
 
     }
 }

--- a/Security/User/CasUserAttributesInterface.php
+++ b/Security/User/CasUserAttributesInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PRayno\CasAuthBundle\Security\User;
+
+interface CasUserAttributesInterface
+{
+
+    /**
+     * @return array
+     */
+    public function getAttributes();
+
+    /**
+     * @return mixed string, array, or null if not found.
+     */
+    public function getAttribute($name);
+
+}

--- a/Security/User/CasUserCredentialStoreInterface.php
+++ b/Security/User/CasUserCredentialStoreInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PRayno\CasAuthBundle\Security\User;
+
+interface CasUserCredentialStoreInterface
+{
+
+  /**
+   * @param array $credentials
+   */
+  public function storeUserCredentials(array $credentials);
+
+}

--- a/Security/User/CasUserProvider.php
+++ b/Security/User/CasUserProvider.php
@@ -36,10 +36,13 @@ class CasUserProvider implements UserProviderInterface, CasUserCredentialStoreIn
             $salt = "";
             $roles = ["ROLE_USER"];
 
-            $user = new CasUser($username, $password, $salt, $roles);
             if (!empty($this->user_credentials[$username])) {
-              $this->populateCasAttributes($user, $this->user_credentials[$username]);
+                $attributes = $this->getCasAttributes($this->user_credentials[$username]);
+            } else {
+                $attributes = array();
             }
+            $user = new CasUser($username, $password, $salt, $roles, $attributes);
+
             return $user;
         }
 
@@ -75,10 +78,10 @@ class CasUserProvider implements UserProviderInterface, CasUserCredentialStoreIn
     }
 
     /**
-     * @param UserInterface $user
      * @param $credentials
+     * @retun array
      */
-    protected function populateCasAttributes(UserInterface $user, $credentials) {
+    protected function getCasAttributes($credentials) {
         $attras = array();
 
         // "Jasig Style" & CAS 3.0 Attributes:
@@ -182,11 +185,6 @@ class CasUserProvider implements UserProviderInterface, CasUserCredentialStoreIn
             }
         }
 
-        // Add the attributes to the user object.
-        foreach ($attras as $name => $value) {
-            if (!isset($user->$name)) {
-                $user->$name = $value;
-            }
-        }
+        return $attras;
     }
 }

--- a/Security/User/CasUserProvider.php
+++ b/Security/User/CasUserProvider.php
@@ -7,8 +7,22 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 
-class CasUserProvider implements UserProviderInterface
+class CasUserProvider implements UserProviderInterface, CasUserCredentialStoreInterface
 {
+
+    protected $user_credentials = array();
+
+    /**
+     * @param array $credentials
+     */
+    public function storeUserCredentials(array $credentials) {
+        if ($credentials['user']) {
+            $this->user_credentials[$credentials['user']] = $credentials;
+        } else {
+            throw new \InvalidArgumentException('Credentials must contain a user property');
+        }
+    }
+
     /**
      * Provides the authenticated user a ROLE_USER
      * @param $username
@@ -22,7 +36,11 @@ class CasUserProvider implements UserProviderInterface
             $salt = "";
             $roles = ["ROLE_USER"];
 
-            return new CasUser($username, $password, $salt, $roles);
+            $user = new CasUser($username, $password, $salt, $roles);
+            if (!empty($this->user_credentials[$username])) {
+              $this->populateCasAttributes($user, $this->user_credentials[$username]);
+            }
+            return $user;
         }
 
         throw new UsernameNotFoundException(
@@ -54,5 +72,121 @@ class CasUserProvider implements UserProviderInterface
     public function supportsClass($class)
     {
         return $class === 'PRayno\CasAuthBundle\Security\User\CasUser';
+    }
+
+    /**
+     * @param UserInterface $user
+     * @param $credentials
+     */
+    protected function populateCasAttributes(UserInterface $user, $credentials) {
+        $attras = array();
+
+        // "Jasig Style" & CAS 3.0 Attributes:
+        //
+        //   <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+        //     <cas:authenticationSuccess>
+        //       <cas:user>jsmith</cas:user>
+        //       <cas:attributes>
+        //         <cas:attraStyle>Jasig</cas:attraStyle>
+        //         <cas:surname>Smith</cas:surname>
+        //         <cas:givenName>John</cas:givenName>
+        //         <cas:memberOf>CN=Staff,OU=Groups,DC=example,DC=edu</cas:memberOf>
+        //         <cas:memberOf>CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu</cas:memberOf>
+        //       </cas:attributes>
+        //       <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2sfa23casd</cas:proxyGrantingTicket>
+        //     </cas:authenticationSuccess>
+        //   </cas:serviceResponse>
+        //
+        if (isset($credentials['attributes'])) {
+            foreach ($credentials['attributes'] as $attribute) {
+                $name = $attribute->getName();
+                $value = $attribute->__toString();
+                // Make an attribute multi-valued on the second one seen.
+                if (isset($attras[$name]) && !is_array($attras[$name])) {
+                    $tmp = $attras[$name];
+                    $attras[$name] = array($tmp);
+                }
+                // Add multi-valued attributes.
+                if (isset($attras[$name])) {
+                    $attras[$name][] = $value;
+                }
+                // Single-valued attributes.
+                else {
+                    $attras[$name] = $value;
+                }
+            }
+        } else {
+            // "Name-Value" attributes.
+            //
+            // Attribute format from these mailing list thread:
+            // http://jasig.275507.n4.nabble.com/CAS-attributes-and-how-they-appear-in-the-CAS-response-td264272.html
+            // Note: This is a less widely used format, but in use by at least two institutions.
+            //
+            //   <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+            //     <cas:authenticationSuccess>
+            //       <cas:user>jsmith</cas:user>
+            //
+            //       <cas:attribute name='attraStyle' value='Name-Value' />
+            //       <cas:attribute name='surname' value='Smith' />
+            //       <cas:attribute name='givenName' value='John' />
+            //       <cas:attribute name='memberOf' value='CN=Staff,OU=Groups,DC=example,DC=edu' />
+            //       <cas:attribute name='memberOf' value='CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu' />
+            //
+            //       <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2sfa23casd</cas:proxyGrantingTicket>
+            //     </cas:authenticationSuccess>
+            //   </cas:serviceResponse>
+            //
+            if (isset($credentials['attribute']) && isset($credentials['attribute'][0]->attributes()['name']) && isset($credentials['attribute'][0]->attributes()['value'])) {
+                foreach ($credentials['attribute'] as $attribute) {
+                    $name = (string)$attribute->attributes()['name'];
+                    $value = (string)$attribute->attributes()['value'];
+                    // Make an attribute multi-valued on the second one seen.
+                    if (isset($attras[$name]) && !is_array($attras[$name])) {
+                        $tmp = $attras[$name];
+                        $attras[$name] = array($tmp);
+                    }
+                    // Add multi-valued attributes.
+                    if (isset($attras[$name])) {
+                        $attras[$name][] = $value;
+                    }
+                    // Single-valued attributes.
+                    else {
+                        $attras[$name] = $value;
+                    }
+                }
+            }
+            // "RubyCAS Style" attributes
+            //
+            //   <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
+            //     <cas:authenticationSuccess>
+            //       <cas:user>jsmith</cas:user>
+            //
+            //       <cas:attraStyle>RubyCAS</cas:attraStyle>
+            //       <cas:surname>Smith</cas:surname>
+            //       <cas:givenName>John</cas:givenName>
+            //       <cas:memberOf>CN=Staff,OU=Groups,DC=example,DC=edu</cas:memberOf>
+            //       <cas:memberOf>CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu</cas:memberOf>
+            //
+            //       <cas:proxyGrantingTicket>PGTIOU-84678-8a9d2sfa23casd</cas:proxyGrantingTicket>
+            //     </cas:authenticationSuccess>
+            //   </cas:serviceResponse>
+            //
+            else {
+                // Test for elements other than our allowed list know to the protocol.
+                $skip = array('user', 'proxyGrantingTicket');
+                foreach ($credentials as $name => $value) {
+                    if (!in_array($name, $skip)) {
+                        $attras[$name] = $value;
+                    }
+                }
+            }
+        }
+
+        // Add the attributes to the user object.
+        foreach ($attras as $name => $value) {
+            if (!isset($user->$name)) {
+                $user->$name = $value;
+            }
+        }
     }
 }

--- a/autoload.php
+++ b/autoload.php
@@ -1,0 +1,7 @@
+<?php
+// if library is in dev environement with its own vendor, include its autoload
+if(file_exists(__DIR__ . '/vendor'))
+    require_once __DIR__ . '/vendor/autoload.php';
+// if library is in vendor of another project, include the global autolaod
+else
+    require_once __DIR__ . '/../../../../autoload.php';

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit
+        backupGlobals               = "false"
+        backupStaticAttributes      = "false"
+        colors                      = "false"
+        convertErrorsToExceptions   = "true"
+        convertNoticesToExceptions  = "true"
+        convertWarningsToExceptions = "true"
+        processIsolation            = "false"
+        stopOnFailure               = "false"
+        syntaxCheck                 = "false"
+        bootstrap                   = "autoload.php"
+>
+
+
+
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+
+
+</phpunit>

--- a/tests/PRayno/CasAuthBundle/Security/CasAuthenticatorTest.php
+++ b/tests/PRayno/CasAuthBundle/Security/CasAuthenticatorTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\PRayno\CasAuthBundle\Security;
+
+use PRayno\CasAuthBundle\Security\CasAuthenticator;
+use PRayno\CasAuthBundle\Security\User\CasUserProvider;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Symfony\Component\HttpFoundation\Request;
+
+class CasAuthenticatorTest extends \PHPUnit_Framework_TestCase {
+
+    public function setUp() {
+        // Setup your guzzle client and mock
+        $this->mockCasServer = new MockHandler();
+        $handler = HandlerStack::create($this->mockCasServer);
+        $client = new Client(['handler' => $handler]);
+
+        $this->authenticator = new CasAuthenticator(array(
+              'server_login_url' => 'https://cas.example.com/cas/',
+              'server_validation_url' => 'https://cas.example.com/cas/serviceValidate',
+              'server_logout_url' => 'https://cas.example.com/cas/logout',
+              'xml_namespace' => 'cas',
+              'options' => array(),
+              'username_attribute' => 'user',
+              'query_ticket_parameter' => 'ticket',
+              'query_service_parameter' => 'service'
+            ),
+            $client);
+
+        $this->provider = new CasUserProvider();
+      }
+
+    public function test_get_user_with_name_only() {
+        // Create a mock response.
+        $response = new Response(
+            200,
+            array('Content-Type' => 'text/xml'),
+            '<?xml version="1.0" encoding="UTF-8"?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+    <cas:authenticationSuccess>
+        <cas:user>testuser</cas:user>
+    </cas:authenticationSuccess>
+</cas:serviceResponse>'
+        );
+        $this->mockCasServer->append($response);
+
+        $request = Request::create('http://app.example.com/?ticket=ABC123-1', 'GET');
+
+        // Get the credentials.
+        $credentials = $this->authenticator->getCredentials($request);
+        $this->assertNotEmpty($credentials);
+        $this->assertEquals('testuser', $credentials['user']);
+
+        // Get the user object for the credentials.
+        $user = $this->authenticator->getUser($credentials, $this->provider);
+        $this->assertEquals('testuser', $user->getUsername());
+        $this->assertEquals(array('ROLE_USER'), $user->getRoles());
+    }
+
+}

--- a/tests/PRayno/CasAuthBundle/Security/CasAuthenticatorTest.php
+++ b/tests/PRayno/CasAuthBundle/Security/CasAuthenticatorTest.php
@@ -91,9 +91,9 @@ class CasAuthenticatorTest extends \PHPUnit_Framework_TestCase {
         $user = $this->authenticator->getUser($credentials, $this->provider);
         $this->assertEquals('testuser', $user->getUsername());
         $this->assertEquals(array('ROLE_USER'), $user->getRoles());
-        $this->assertEquals('Smith', $user->surname);
-        $this->assertEquals('John', $user->givenName);
-        $this->assertEquals(array('CN=Staff,OU=Groups,DC=example,DC=edu', 'CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu'), $user->memberOf);
+        $this->assertEquals('Smith', $user->getAttribute('surname'));
+        $this->assertEquals('John', $user->getAttribute('givenName'));
+        $this->assertEquals(array('CN=Staff,OU=Groups,DC=example,DC=edu', 'CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu'), $user->getAttribute('memberOf'));
     }
 
     public function test_get_user_with_name_value_attributes() {
@@ -125,9 +125,9 @@ class CasAuthenticatorTest extends \PHPUnit_Framework_TestCase {
         $user = $this->authenticator->getUser($credentials, $this->provider);
         $this->assertEquals('testuser', $user->getUsername());
         $this->assertEquals(array('ROLE_USER'), $user->getRoles());
-        $this->assertEquals('Smith', $user->surname);
-        $this->assertEquals('John', $user->givenName);
-        $this->assertEquals(array('CN=Staff,OU=Groups,DC=example,DC=edu', 'CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu'), $user->memberOf);
+        $this->assertEquals('Smith', $user->getAttribute('surname'));
+        $this->assertEquals('John', $user->getAttribute('givenName'));
+        $this->assertEquals(array('CN=Staff,OU=Groups,DC=example,DC=edu', 'CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu'), $user->getAttribute('memberOf'));
     }
 
     public function test_get_user_with_rubycas_attributes() {
@@ -159,9 +159,9 @@ class CasAuthenticatorTest extends \PHPUnit_Framework_TestCase {
         $user = $this->authenticator->getUser($credentials, $this->provider);
         $this->assertEquals('testuser', $user->getUsername());
         $this->assertEquals(array('ROLE_USER'), $user->getRoles());
-        $this->assertEquals('Smith', $user->surname);
-        $this->assertEquals('John', $user->givenName);
-        $this->assertEquals(array('CN=Staff,OU=Groups,DC=example,DC=edu', 'CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu'), $user->memberOf);
+        $this->assertEquals('Smith', $user->getAttribute('surname'));
+        $this->assertEquals('John', $user->getAttribute('givenName'));
+        $this->assertEquals(array('CN=Staff,OU=Groups,DC=example,DC=edu', 'CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu'), $user->getAttribute('memberOf'));
     }
 
 

--- a/tests/PRayno/CasAuthBundle/Security/CasAuthenticatorTest.php
+++ b/tests/PRayno/CasAuthBundle/Security/CasAuthenticatorTest.php
@@ -60,4 +60,109 @@ class CasAuthenticatorTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(array('ROLE_USER'), $user->getRoles());
     }
 
+    public function test_get_user_with_jasig_attributes() {
+        // Create a mock response.
+        $response = new Response(
+            200,
+            array('Content-Type' => 'text/xml'),
+            '<?xml version="1.0" encoding="UTF-8"?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+    <cas:authenticationSuccess>
+        <cas:user>testuser</cas:user>
+        <cas:attributes>
+            <cas:surname>Smith</cas:surname>
+            <cas:givenName>John</cas:givenName>
+            <cas:memberOf>CN=Staff,OU=Groups,DC=example,DC=edu</cas:memberOf>
+            <cas:memberOf>CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu</cas:memberOf>
+        </cas:attributes>
+    </cas:authenticationSuccess>
+</cas:serviceResponse>'
+        );
+        $this->mockCasServer->append($response);
+
+        $request = Request::create('http://app.example.com/?ticket=ABC123-1', 'GET');
+
+        // Get the credentials.
+        $credentials = $this->authenticator->getCredentials($request);
+        $this->assertNotEmpty($credentials);
+        $this->assertEquals('testuser', $credentials['user']);
+
+        // Get the user object for the credentials.
+        $user = $this->authenticator->getUser($credentials, $this->provider);
+        $this->assertEquals('testuser', $user->getUsername());
+        $this->assertEquals(array('ROLE_USER'), $user->getRoles());
+        $this->assertEquals('Smith', $user->surname);
+        $this->assertEquals('John', $user->givenName);
+        $this->assertEquals(array('CN=Staff,OU=Groups,DC=example,DC=edu', 'CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu'), $user->memberOf);
+    }
+
+    public function test_get_user_with_name_value_attributes() {
+        // Create a mock response.
+        $response = new Response(
+            200,
+            array('Content-Type' => 'text/xml'),
+            '<?xml version="1.0" encoding="UTF-8"?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+    <cas:authenticationSuccess>
+        <cas:user>testuser</cas:user>
+        <cas:attribute name="surname" value="Smith" />
+        <cas:attribute name="givenName" value="John" />
+        <cas:attribute name="memberOf" value="CN=Staff,OU=Groups,DC=example,DC=edu" />
+        <cas:attribute name="memberOf" value="CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu" />
+    </cas:authenticationSuccess>
+</cas:serviceResponse>'
+        );
+        $this->mockCasServer->append($response);
+
+        $request = Request::create('http://app.example.com/?ticket=ABC123-1', 'GET');
+
+        // Get the credentials.
+        $credentials = $this->authenticator->getCredentials($request);
+        $this->assertNotEmpty($credentials);
+        $this->assertEquals('testuser', $credentials['user']);
+
+        // Get the user object for the credentials.
+        $user = $this->authenticator->getUser($credentials, $this->provider);
+        $this->assertEquals('testuser', $user->getUsername());
+        $this->assertEquals(array('ROLE_USER'), $user->getRoles());
+        $this->assertEquals('Smith', $user->surname);
+        $this->assertEquals('John', $user->givenName);
+        $this->assertEquals(array('CN=Staff,OU=Groups,DC=example,DC=edu', 'CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu'), $user->memberOf);
+    }
+
+    public function test_get_user_with_rubycas_attributes() {
+        // Create a mock response.
+        $response = new Response(
+            200,
+            array('Content-Type' => 'text/xml'),
+            '<?xml version="1.0" encoding="UTF-8"?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+    <cas:authenticationSuccess>
+        <cas:user>testuser</cas:user>
+        <cas:surname>Smith</cas:surname>
+        <cas:givenName>John</cas:givenName>
+        <cas:memberOf>CN=Staff,OU=Groups,DC=example,DC=edu</cas:memberOf>
+        <cas:memberOf>CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu</cas:memberOf>
+    </cas:authenticationSuccess>
+</cas:serviceResponse>'
+        );
+        $this->mockCasServer->append($response);
+
+        $request = Request::create('http://app.example.com/?ticket=ABC123-1', 'GET');
+
+        // Get the credentials.
+        $credentials = $this->authenticator->getCredentials($request);
+        $this->assertNotEmpty($credentials);
+        $this->assertEquals('testuser', $credentials['user']);
+
+        // Get the user object for the credentials.
+        $user = $this->authenticator->getUser($credentials, $this->provider);
+        $this->assertEquals('testuser', $user->getUsername());
+        $this->assertEquals(array('ROLE_USER'), $user->getRoles());
+        $this->assertEquals('Smith', $user->surname);
+        $this->assertEquals('John', $user->givenName);
+        $this->assertEquals(array('CN=Staff,OU=Groups,DC=example,DC=edu', 'CN=Spanish Department,OU=Departments,OU=Groups,DC=example,DC=edu'), $user->memberOf);
+    }
+
+
 }

--- a/tests/PRayno/CasAuthBundle/Security/CasAuthenticatorTest.php
+++ b/tests/PRayno/CasAuthBundle/Security/CasAuthenticatorTest.php
@@ -9,6 +9,8 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 class CasAuthenticatorTest extends \PHPUnit_Framework_TestCase {
 
@@ -30,7 +32,7 @@ class CasAuthenticatorTest extends \PHPUnit_Framework_TestCase {
             ),
             $client);
 
-        $this->provider = new CasUserProvider();
+        $this->provider = new CasUserProvider(new Session(new MockArraySessionStorage()));
       }
 
     public function test_get_user_with_name_only() {


### PR DESCRIPTION
Hi @PRayno, here is a first pass at providing user attributes that might be contained in the CAS response as part of the CasUser object, to resolve #5.

In order to test this, I needed to add some unit tests and supporting files so that `phpunit` would run.

Also, in order for the attributes to be maintained so that they can be used on subsequent page-loads when `CasUserProvider->loadUserByUsername()` gets called, I needed to inject the Session service into the `CasUserProvider`. While is easy to do in an application's `services.yml`, I couldn't figure out a way to have that service injected in the `PRaynoCasAuthExtension::load()` method or other way that would just work without requiring the extra configuration step. As far as I can tell only the username gets automatically persisted in the session -- not the full user object, though maybe there is another way to tell Symfony to persist the full user object.

While this PR is currently operational, there could certainly be a better way to accomplish this goal. 
