### PR TITLE
Retrieve attributes returned by CAS and pass them to a provider

### DIFF
--- a/Security/CasAuthenticator.php
+++ b/Security/CasAuthenticator.php
@@ -4,6 +4,7 @@ namespace PRayno\CasAuthBundle\Security;
 
 use GuzzleHttp\Client;
 use PRayno\CasAuthBundle\Event\CASAuthenticationFailureEvent;
+use PRayno\CasAuthBundle\Security\User\CasUserProviderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -83,12 +84,20 @@ class CasAuthenticator extends AbstractGuardAuthenticator
      * Calls the UserProvider providing a valid User
      * @param array $credentials
      * @param UserProviderInterface $userProvider
-     * @return bool
+     * @return UserInterface|null
      */
     public function getUser($credentials, UserProviderInterface $userProvider)
     {
         if (isset($credentials[$this->username_attribute])) {
-            return $userProvider->loadUserByUsername($credentials[$this->username_attribute]);
+            if($userProvider instanceof CasUserProviderInterface)
+            {
+                $attributes = (isset($credentials['attributes']))? (array)$credentials['attributes'] : [];
+                return $userProvider->loadUserByUsernameAndAttributes($credentials[$this->username_attribute], $attributes);
+            }
+            else
+            {
+                return $userProvider->loadUserByUsername($credentials[$this->username_attribute]);
+            }
         } else {
             return null;
         }

--- a/Security/User/CasUserProviderInterface.php
+++ b/Security/User/CasUserProviderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace PRayno\CasAuthBundle\Security\User;
+
+
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+/**
+ * Interface CasUserProviderInterface
+ * @package Security\User
+ */
+interface CasUserProviderInterface extends UserProviderInterface
+{
+    /**
+     * @param string $username
+     * @param array $attributes
+     * @return UserInterface
+     * @throws UsernameNotFoundException if the user is not found
+     */
+    public function loadUserByUsernameAndAttributes(string $username, array $attributes);
+
+}


### PR DESCRIPTION
Allows the authenticator to retrieve the attributes returned by CAS and pass it to a provider that implements CasUserProviderInterface. This avoids having to re-query the repository (ldap, bdd, ...) to retrieve user information.